### PR TITLE
move to utilize /etc/os-release on linux, which should be standard by…

### DIFF
--- a/git-commit.sh
+++ b/git-commit.sh
@@ -29,6 +29,7 @@ STATCMD="stat_-f_%Sp %5l %6u %6g %12z %m %N"
 SORTCMD="sort_-z"
 DIRS="/etc"
 EXTRA_FILES=""
+ID=""
 
 # Choose commands based on kernel name and some other things for Linux
 case "`uname`" in
@@ -42,7 +43,6 @@ case "`uname`" in
 		elif [ -e /etc/alpine-release ]; then
 			apk -vv info | sort > 00PACKAGES
 		else
-			ID=""
 			if [ -e /etc/os-release ]; then
 				. /etc/os-release
 			fi

--- a/git-commit.sh
+++ b/git-commit.sh
@@ -42,8 +42,19 @@ case "`uname`" in
 		elif [ -e /etc/alpine-release ]; then
 			apk -vv info | sort > 00PACKAGES
 		else
-			echo >&2 "Unknown Linux dist"
-			exit 1
+			ID=""
+			if [ -e /etc/os-release ]; then
+				. /etc/os-release
+			fi
+			case "${ID}" in
+				void)
+					xbps-query -l | cut -d' ' -f2 > 00PACKAGES
+					;;
+				*)
+					echo >&2 "Unknown Linux dist"
+					exit 1
+					;;
+			esac
 		fi
 		;;
 	FreeBSD)


### PR DESCRIPTION
added void linux and changed to utilize /etc/os-release, void linux doesn't seem to utilize any specific dist file identifier beyond os-release.